### PR TITLE
Configure Dependabot for npm with multiple directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "apps/*"
+      - "packages/*"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Updated Dependabot configuration to specify npm ecosystem and added directories for package manifests.